### PR TITLE
[codex] Clarify artwork plugin purpose

### DIFF
--- a/Jellyfin.Plugin.Artwork/ArtworkPlugin.cs
+++ b/Jellyfin.Plugin.Artwork/ArtworkPlugin.cs
@@ -38,7 +38,7 @@ namespace Jellyfin.Plugin.Artwork
         public override string Name => "Artwork";
 
         /// <inheritdoc />
-        public override string Description => "Get artwork from repo";
+        public override string Description => "Download studio artwork from configured repositories";
 
         /// <inheritdoc />
         public IEnumerable<PluginPageInfo> GetPages()

--- a/README.md
+++ b/README.md
@@ -2,8 +2,37 @@
 <h3 align="center">Part of the <a href="https://jellyfin.org">Jellyfin Project</a></h3>
 
 <p align="center">
-This plugin is built with .NET to download artwork.
+Download studio artwork for Jellyfin from configured artwork repositories.
 </p>
+
+## About
+
+The Artwork plugin adds a remote image provider for Jellyfin studio entries.
+When Jellyfin looks up artwork for a studio, the plugin checks the configured
+artwork repositories and returns matching images.
+
+Supported image types:
+
+- Primary
+- Thumb
+- Logo
+- Backdrop
+
+The plugin is intended to be used with artwork repositories such as the
+[Jellyfin Artwork Repository](https://github.com/jellyfin/jellyfin-artwork),
+which provides studio images and the metadata needed to match them to Jellyfin
+items.
+
+## Configuration
+
+1. Install the plugin.
+2. Open the Artwork plugin settings in the Jellyfin dashboard.
+3. Add one or more artwork repositories.
+4. Save the configuration and refresh studio metadata.
+
+An artwork repository is expected to expose a `studios.json` file and matching
+image files under a `studios/` directory. The plugin matches entries by provider
+IDs such as IMDb, TMDb, TVDb, AniList, and MusicBrainz where available.
 
 ## Build Process
 
@@ -16,4 +45,5 @@ This plugin is built with .NET to download artwork.
 ```sh
 dotnet publish --configuration Release --output bin
 ```
+
 4. Place the resulting file in the `plugins` folder under the program data directory or inside the portable install directory

--- a/build.yaml
+++ b/build.yaml
@@ -5,9 +5,10 @@ version: 2
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 owner: "jellyfin"
-overview: "Download artwork"
+overview: "Download studio artwork"
 description: >
-  Downloads artwork from a repository for various media types.
+  Provides studio artwork for Jellyfin by reading configured artwork
+  repositories and exposing matching remote images.
 
 category: "General"
 artifacts:


### PR DESCRIPTION
## Summary
- expand the README with a clearer explanation of what the Artwork plugin does
- document supported image types and basic repository configuration
- update the plugin catalog metadata and in-app description to say this is for studio artwork

## Why
This addresses #23 by making the README and catalog text more specific for users evaluating the plugin.

## Validation
- dotnet build
- git diff --check